### PR TITLE
Fixed Serial baudrate problems 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If your project requires computer control or a set of instruction, a library lik
 #### gcode(),<br> gcode(void (*CallBack)()),<br> gcode(int numbercommands, commandscallback *commandArray),<br> gcode(int numbercommands, commandscallback *commandArray, void (*CallBack)());
 This Function is used to declare this class so that it can be used in the program. There are 4 different functions, each with variables that can be set. The *callback* is used to link a call back function used after each command is available. *commandArray* is an array of callback that interupt the program to execute the command. *Numbercommands* is the number of items within commandArray.
 
-#### void begin(),<br> void begin(int bitrate)
+#### void begin(),<br> void begin(unsigned long baud)
 This Function must be called if the serial interface is wanting to be used. *Bitrate* is the bitrate of the serial port. If this is called, there is no need to *Serial.begin();*, it is apart of the begin function.
 
 ### SEND 

--- a/gcode.cpp
+++ b/gcode.cpp
@@ -54,17 +54,17 @@ void gcode::begin(String nextComandcomment)
   this->clearBuffer();
 }
 
-void gcode::begin(int bitrate)
+void gcode::begin(unsigned long baud)
 {
-  Serial.begin(bitrate);
+  Serial.begin(baud);
   Serial.println("v" +String(gcode_Buffer_version)+" Simple G code");
   nextComandcommentString = "OK!";
   this->clearBuffer();
 }
 
-void gcode::begin(int bitrate, String nextComandcomment)
+void gcode::begin(unsigned long baud, String nextComandcomment)
 {
-  Serial.begin(bitrate);
+  Serial.begin(baud);
   Serial.println("v" +String(gcode_Buffer_version)+" Simple G code");
   nextComandcommentString = nextComandcomment;
   this->clearBuffer();
@@ -78,9 +78,9 @@ void gcode::begin(void (*_nextComandCallBack)())
   this->clearBuffer();
 }
 
-void gcode::begin(int bitrate, void (*_nextComandCallBack)())
+void gcode::begin(unsigned long baud, void (*_nextComandCallBack)())
 {
-  Serial.begin(bitrate);
+  Serial.begin(baud);
   Serial.println("v" +String(gcode_Buffer_version)+" Simple G code");
   nextComandCallBack = _nextComandCallBack;
   this->clearBuffer();

--- a/gcode.h
+++ b/gcode.h
@@ -35,11 +35,11 @@ class gcode
         gcode(int numbercommands, commandscallback *commandscallbacks_temp);
         gcode(int numbercommands, commandscallback *commandscallbacks_temp, void (*CallBack)());
         void begin();
-        void begin(int bitrate);
+        void begin(unsigned long baud);
         void begin(String nextComandcomment);
-        void begin(int bitrate, String nextComandcomment);
+        void begin(unsigned long baud, String nextComandcomment);
         void begin(void (*_nextComandCallBack)());
-        void begin(int bitrate, void (*_nextComandCallBack)());
+        void begin(unsigned long baud, void (*_nextComandCallBack)());
 
         // SEND 
         void comment(String comment);


### PR DESCRIPTION
### Problem
The library worked only using the default baudrate. By defining another baudrate in the begin() function the Arduino Serial function got the wrong baudrate and no communication can be established. This problem occurs because the library uses an integer for storing the defined baud and passes this to the Arduino function which expects an unsigned long. Unfortunately this is not an exception which the compiler catches.

### Solution
I changed all the instances of the integer bitrate to an unsigned long and updated the README.md file to show the correct input for the begin() function. Further I changed bitrate to baud since it is not a bitrate.